### PR TITLE
destroyアクションの編集とbefore_actionの追加

### DIFF
--- a/app/controllers/api/songs_controller.rb
+++ b/app/controllers/api/songs_controller.rb
@@ -1,4 +1,6 @@
 class Api::SongsController < ApplicationController
+  before_action :select_song, only: [ :destroy ]
+
   def index
     all_songs
   end
@@ -26,6 +28,7 @@ class Api::SongsController < ApplicationController
   end
 
   def destroy
+    @song.destroy
     all_songs
   end
 


### PR DESCRIPTION
# why

- フロントエンドから送信されてきたリクエストを受け取り曲を削除する。

# what

- before_actionを使って、送られてきたidから曲を取得すためbefore_actionを定義し、@songに代入をする。
- destroyアクションを編集し、@songにdestoryメソッドを使って曲を削除する。
